### PR TITLE
Docs/validation update to allow same sex rape and note that 11B and 11C will be published at the federal level as 11A.

### DIFF
--- a/_data/error.json
+++ b/_data/error.json
@@ -1444,15 +1444,6 @@
 			"36": "For NIBRS <b>09C</b> Offenses (Justifiable Homicide) at least one of the Offenders must have known information for Age, Sex, and Race. Unknown ('000') is not valid as an Offender Sequence Number (DE 36) for these Offenses."
 		}
 	},
-	"14060": {
-		"active": "true",
-		"err_no": 14060,
-		"err_message": "VICTIM'S SEX CANNOT BE SAME AS ALL OFFENDERS FOR OFFENSES OF '11A'",
-		"err_desc": {
-			"27": "When the Offense Code is 11A, at least one of the Offenders must be a different sex than the Victim(s). If all Victims and Offenders are the same sex, 11B, 11C, or 11D may be the offense code you actually want to use.",
-			"38": "When the Offense Code is 11A, at least one of the Offenders must be a different sex than the Victim(s). If all Victims and Offenders are the same sex, 11B, 11C, or 11D may be the offense code you actually want to use."
-		}
-	},
 	"14061": {
 		"active": "false",
 		"err_no": 14061,

--- a/index.md
+++ b/index.md
@@ -43,6 +43,11 @@ Please don't hesitate to let us know if you have any questions or problems using
 
 ### Change Log:
 
+#### 2025-12-09
+
+* Removed error code 14060 from Sex of Offender (38) and Sex of Victim (27) due to law changes.
+* Removed error code 14060 from error.json since it is no longer used.
+
 #### 2025-05-09
 
 * Added LIBRS warning if Bias Motivation is Unknown. Unknown should only be used when there is a question under investigation about a bias motivation / hate crime.

--- a/librs-spec.md
+++ b/librs-spec.md
@@ -3281,10 +3281,8 @@ Requirement  | Requirement Description | Error Number | Error Message
 :-----------:|-------------------------|:------------:|----------
 {% assign error = site.data.error["11004"] -%}
 1 | {{error.err_desc["27"]}} | {{error.err_no}}| {{ error.err_message }}
-{% assign error = site.data.error["14060"] -%}
-2 | {{error.err_desc["27"]}} | {{error.err_no}}| {{ error.err_message }}
 {% assign error = site.data.error["15058"] -%}
-3 | {{error.err_desc["27"]}} | {{error.err_no}}| {{ error.err_message }}
+2 | {{error.err_desc["27"]}} | {{error.err_no}}| {{ error.err_message }}
 
 
 ___
@@ -4163,8 +4161,6 @@ Requirement  | Requirement Description | Error Number | Error Message
 {% assign error = site.data.error["11004"] -%}
 2 | {{error.err_desc["38"]}} | {{error.err_no}}| {{ error.err_message }} 
 {% assign error = site.data.error["14052"] -%}
-3 | {{error.err_desc["38"]}} | {{error.err_no}}| {{ error.err_message }}
-{% assign error = site.data.error["14060"] -%}
 3 | {{error.err_desc["38"]}} | {{error.err_no}}| {{ error.err_message }}
 
 


### PR DESCRIPTION
# Changes:
- Removed error 14060 from docs error.json.
- Removed requirement 2 from Victims of Sex (27).
- Removed the second requirement # 3 from Offenders of Sex (38).
- Updated change log in index.md.

# Asana Tasks Involved:
- [Docs/validation update to allow same sex rape and note that 11B and 11C will be published at the federal level as 11A.](https://app.asana.com/1/121567981976/project/1203938031651467/task/1211723340206399?focus=true)